### PR TITLE
Fix for Window title is wrong

### DIFF
--- a/src/gui/maindialog.ui
+++ b/src/gui/maindialog.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>qfit</string>
   </property>
   <property name="windowIcon">
    <iconset resource="resources.qrc">

--- a/src/gui/maindialog_noqwt.ui
+++ b/src/gui/maindialog_noqwt.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>qfit</string>
   </property>
   <property name="windowIcon">
    <iconset resource="resources.qrc">


### PR DESCRIPTION
Changed the windowTitle property to the application's name (Fixes #2).